### PR TITLE
moving objects script

### DIFF
--- a/SPOOP/Assets/Scripts.meta
+++ b/SPOOP/Assets/Scripts.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 939c48b3e9d3c4e7b9cb9050bfe14a61
+folderAsset: yes
+timeCreated: 1518127795
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/SPOOP/Assets/Scripts/Moving.cs
+++ b/SPOOP/Assets/Scripts/Moving.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+//to be applied to the object that moves
+public class Moving : MonoBehaviour
+{
+	public int moveSpeed;
+
+	private Vector3 moveDirection;
+	private Vector3 endPosition;
+	private bool moving;
+
+	void Start()
+	{
+		moving = false;
+	}
+
+	void Update()
+	{
+		//move
+		if (moving)
+			transform.Translate (moveDirection * moveSpeed * Time.deltaTime);
+
+		//move until close enough to end position
+		if (Vector3.Distance (transform.position, endPosition) < 0.1)
+			moving = false;
+	}
+
+	void OnCollisionEnter(Collision coll)
+	{
+		if (!moving) //make sure we don't change direction while already moving
+		{
+			var normal = coll.contacts [0].normal;
+			if (normal != Vector3.up && //don't move on collisions with floor
+				//only move in diagonals
+			   (normal == Vector3.forward || normal == Vector3.right || normal == Vector3.left || normal == Vector3.back))
+			{
+				moving = true;
+				moveDirection = normal;
+				endPosition = transform.position + moveDirection;
+			}
+		}
+	}
+}

--- a/SPOOP/Assets/Scripts/Moving.cs.meta
+++ b/SPOOP/Assets/Scripts/Moving.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: bd0fba5270d7947c3a5a7e0ccae6740c
+timeCreated: 1518129631
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/SPOOP/Assets/Scripts/PlayerController.cs.meta
+++ b/SPOOP/Assets/Scripts/PlayerController.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 1f662851b20c349dab748af46d6fb730
+timeCreated: 1518135240
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
ignore the .meta differences idk why those were things. maybe we should add them to the gitignore

script to add to objects that can be moved