### PR TITLE
Gravity Changing Bugs

### DIFF
--- a/SPOOP/Assets/Scenes/Sandbox.unity
+++ b/SPOOP/Assets/Scenes/Sandbox.unity
@@ -113,6 +113,90 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &327669049
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 327669053}
+  - component: {fileID: 327669052}
+  - component: {fileID: 327669051}
+  - component: {fileID: 327669050}
+  m_Layer: 0
+  m_Name: Checkpoint
+  m_TagString: Ground
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &327669050
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 327669049}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!65 &327669051
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 327669049}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &327669052
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 327669049}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &327669053
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 327669049}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 10.9}
+  m_LocalScale: {x: 10, y: 0.5, z: 10}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &554815137
 GameObject:
   m_ObjectHideFlags: 0
@@ -206,6 +290,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6e8a119dbe2a9044fa88707aed7aadf8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  gravity: 0
 --- !u!1001 &668949793
 Prefab:
   m_ObjectHideFlags: 0
@@ -219,7 +304,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4223175299712636, guid: 4a3f672030fa47c4c93ac47045f7ab6a, type: 2}
       propertyPath: m_LocalPosition.y
-      value: 0.5
+      value: 0.75
       objectReference: {fileID: 0}
     - target: {fileID: 4223175299712636, guid: 4a3f672030fa47c4c93ac47045f7ab6a, type: 2}
       propertyPath: m_LocalPosition.z
@@ -275,7 +360,7 @@ GameObject:
   - component: {fileID: 978793548}
   - component: {fileID: 978793547}
   m_Layer: 0
-  m_Name: Checkpoint
+  m_Name: first
   m_TagString: Ground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -342,7 +427,7 @@ Transform:
   m_GameObject: {fileID: 978793546}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 10, y: 0.1, z: 10}
+  m_LocalScale: {x: 10, y: 0.5, z: 10}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 4
@@ -359,7 +444,7 @@ GameObject:
   - component: {fileID: 1203521705}
   - component: {fileID: 1203521704}
   m_Layer: 0
-  m_Name: Checkpoint
+  m_Name: cube
   m_TagString: Ground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -426,7 +511,7 @@ Transform:
   m_GameObject: {fileID: 1203521703}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 17, z: 0}
-  m_LocalScale: {x: 10, y: 0.1, z: 10}
+  m_LocalScale: {x: 10, y: 0.5, z: 10}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 5

--- a/SPOOP/Assets/Scripts/CameraController.cs
+++ b/SPOOP/Assets/Scripts/CameraController.cs
@@ -2,13 +2,16 @@
 using System.Collections;
 
 // attach script to main camera
-public class CameraController : MonoBehaviour {
-
+public class CameraController : MonoBehaviour
+{
+    public bool gravity;
     private GameObject player;
     private Vector3 offset;
     private Quaternion normalGravity, reverseGravity;
-    private bool gravity;
     private float yOffset;
+
+    public float switchRate = 1f;
+    private float timeToSwitch = 0f;
 
     void Start ()
     {
@@ -44,8 +47,13 @@ public class CameraController : MonoBehaviour {
         }
 
         //reverse gravity
-        if (Input.GetKeyDown (KeyCode.E) && player.GetComponent<PlayerController> ().level2Completed)
+        if (Input.GetKeyDown (KeyCode.E)
+            && player.GetComponent<PlayerController> ().level2Completed
+            && Time.time >= timeToSwitch)
+        {
+            timeToSwitch = Time.time + 1f / switchRate;
             gravity = !gravity;
+        }
     }
 
     void LateUpdate ()

--- a/SPOOP/Assets/Scripts/PlayerController.cs
+++ b/SPOOP/Assets/Scripts/PlayerController.cs
@@ -60,11 +60,17 @@ public class PlayerController : MonoBehaviour
             if (transform.position.y <= -10f || transform.position.y >= 20f)
             {
                 //if spawn location is on floor, gravity is down
-                if (spawnLocation.y == 0)
-                    Physics.gravity = new Vector3 (0, -1, 0);
+                if (spawnLocation.y == 0.75f)
+                {
+                    Physics.gravity = new Vector3 (0, -9.8f, 0);
+                    GameObject.FindWithTag ("MainCamera").GetComponent<CameraController> ().gravity = true;
+                }
                 //if spawn location is on ceiling, gravity is up
                 else
-                    Physics.gravity = new Vector3 (0, 1, 0);
+                {
+                    Physics.gravity = new Vector3 (0, 9.8f, 0);
+                    GameObject.FindWithTag ("MainCamera").GetComponent<CameraController> ().gravity = false;
+                }
                 transform.position = spawnLocation;
                 obstacle.gameObject.GetComponent<ObstacleController> ().resetPos ();
                 obstacle.SetActive (false);
@@ -97,7 +103,10 @@ public class PlayerController : MonoBehaviour
 
         if (other.gameObject.name == "dude lookout" && obstacle.activeSelf == false) 
             obstacle.SetActive (true);
+    }
 
+    void OnCollisionEnter(Collision other)
+    {
         if (other.gameObject.name == "Checkpoint") 
         {
             spawnLocation = other.transform.position;


### PR DESCRIPTION
since the checkpoint assignment was in OnCollisionStay, when gravity was switched, the respawn point changed from +0.75 to -0.75, moving that to OnCollisionEnter fixed this

there is a delay in the player controller so you can't spam gravity changes that was not in camera, this fixed the double tap issue